### PR TITLE
Sharing a single visual canvas between layers

### DIFF
--- a/packages/draw/src/artist.ts
+++ b/packages/draw/src/artist.ts
@@ -5,7 +5,6 @@ import { HighlightVariant, MindGraphConfig } from './types';
 
 interface Layer {
   drawables: Drawable[];
-  canvas: Canvas;
   variant: HighlightVariant;
 }
 
@@ -29,20 +28,13 @@ export class Artist {
     });
     this.zoomer = new Zoomer();
 
-    const memoryCanvasConfig = {
-      initialWidth: this.visual_canvas.node()?.width || 0,
-      initialHeight: this.visual_canvas.node()?.height || 0,
-    };
-
     this.drawables = [];
     this.baseLayer = {
       drawables: [],
-      canvas: new Canvas(undefined, memoryCanvasConfig),
       variant: 'normal',
     };
     this.activeLayer = {
       drawables: [],
-      canvas: new Canvas(undefined, memoryCanvasConfig),
       variant: 'active',
     };
   }
@@ -59,17 +51,19 @@ export class Artist {
 
     const layers = [this.baseLayer, this.activeLayer];
 
-    for (const layer of layers) {
-      layer.canvas.drawFrame({
-        zoomer: this.zoomer,
-        drawables: layer.drawables,
-        config: {
-          highlight: layer.variant,
-        },
-      });
-    }
+    this.visual_canvas?.clear();
 
-    this.visual_canvas?.drawImage(layers.map((l) => l.canvas.node()));
+    for (const layer of layers) {
+      if (this.visual_canvas) {
+        this.visual_canvas.drawFrame({
+          zoomer: this.zoomer,
+          drawables: layer.drawables,
+          config: {
+            highlight: layer.variant,
+          },
+        });
+      }
+    }
   }
 
   public makeInteractive(): void {

--- a/packages/draw/src/canvas.ts
+++ b/packages/draw/src/canvas.ts
@@ -108,6 +108,15 @@ export class Canvas {
     }
   }
 
+  public clear() {
+    this.context?.clearRect(
+      0,
+      0,
+      Number(this.canvasElement.attr('width')),
+      Number(this.canvasElement.attr('height')),
+    );
+  }
+
   public drawFrame({
     zoomer,
     drawables,
@@ -122,13 +131,6 @@ export class Canvas {
     if (!this.context) return;
 
     this.context.save();
-
-    this.context.clearRect(
-      0,
-      0,
-      Number(this.canvasElement.attr('width')),
-      Number(this.canvasElement.attr('height')),
-    );
 
     this.context.translate(zoomer.x, zoomer.y);
     this.context.scale(zoomer.k, zoomer.k);


### PR DESCRIPTION
This PR is part of the review against "i18/layers". 

I'm curious about the benefits of maintaining 3 separate "HtmlCanvasElements" in memory, vs a single a single canvas that is bound to the actual canvas that is present in the HTML.

We can share this in memory canvas amongst the layers, and the layers are only really used to track which drawables are in which layer.

This also moves the rectangle clearing logic up to the artist so that the screen isn't completely cleared in between layer renders.